### PR TITLE
nablarch-workflowのバージョンの記載を削除。

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,6 @@
     <dependency>
       <groupId>com.nablarch.workflow</groupId>
       <artifactId>nablarch-workflow</artifactId>
-      <version>1.1.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## 背景

https://github.com/nablarch/nablarch-profiles/pull/50 の対応により、本pom.xmlにnablarch-workflowバージョンを明記する必要がなくなった。そのため、nablarch-workflowのバージョンを削除。

## 対応
- nablarch-workflowのバージョン記載の削除

## 補足

本修正は単独でのリリース不要。  
今後nablarch-workflow-toolに変更があった場合にリリースする。